### PR TITLE
Work around missing clock_gettime on Mac OS

### DIFF
--- a/SHMEM/isx.c
+++ b/SHMEM/isx.c
@@ -102,6 +102,8 @@ static char * parse_params(const int argc, char ** argv)
       printf("Usage:  \n");
       printf("  ./%s <num_pes> <total num keys(strong) | keys per pe(weak)> <log_file>\n",argv[0]);
     }
+
+    shmem_finalize();
     exit(0);
   }
 
@@ -142,6 +144,8 @@ static char * parse_params(const int argc, char ** argv)
         if(shmem_my_pe() == 0){
           printf("Invalid scaling option! See params.h to define the scaling option.\n");
         }
+
+        shmem_finalize();
         exit(0);
         break;
       }

--- a/SHMEM/isx.h
+++ b/SHMEM/isx.h
@@ -112,6 +112,14 @@ static void verify_results(int const * restrict const my_local_key_counts,
 static inline pcg32_random_t seed_my_rank(void);
 
 /*
+ * Provides a sequential ordering of PE operations
+ */
+#ifdef DEBUG
+static void wait_my_turn();
+static void my_turn_complete();
+#endif
+
+/*
  * Initializes the sync array needed by shmem collective operations.
  */
 static void init_shmem_sync_array(long * restrict const pSync);

--- a/SHMEM/isx.h
+++ b/SHMEM/isx.h
@@ -45,7 +45,7 @@ static char * parse_params(const int argc, char ** argv);
  * Each bucket is assigned to a PE and all keys belonging to a bucket are sent
  * to the corresponding PE. Each PE then performs a local sort of the keys in its bucket.
  */
-static void bucket_sort();
+static int bucket_sort();
 
 #ifdef PERMUTE
 /*
@@ -103,7 +103,7 @@ static inline int * count_local_keys(KEY_TYPE const * restrict const my_bucket_k
  * Ensures all keys after the exchange are within a PE's bucket boundaries.
  * Ensures the final number of keys is equal to the initial.
  */
-static void verify_results(int const * restrict const my_local_key_counts, 
+static int verify_results(int const * restrict const my_local_key_counts, 
                            KEY_TYPE const * restrict const my_local_keys);
 
 /*


### PR DESCRIPTION
This PR is based on #10.  The new change being proposed is 3d7f354.

This code is cribbed from a gist posted online with no license.  It seems reasonable to consider this gist as public domain and include it with acknowledgement, but someone else who knows better should make the call as to whether this is doable under the license used by ISx.
