### PR TITLE
Bug fix for the shuffle method in PERMUTE mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
     - git clone https://github.com/Sandia-OpenSHMEM/SOS.git src/sandia-shmem
     - cd src/sandia-shmem
     - ./autogen.sh
-    - ./configure --with-ofi=$HOME/opt/libfabric/ --disable-fortran --prefix=$HOME/opt/sandia-shmem-ofi --enable-error-checking --enable-remote-virtual-addressing --enable-picky --enable-pmi-simple
+    - ./configure --with-ofi=$HOME/opt/libfabric/ --disable-fortran --prefix=$HOME/opt/sandia-shmem-ofi --enable-error-checking --enable-picky --enable-pmi-simple
     - make -j 4
     - make install
     - cd ../..

--- a/SHMEM/isx.c
+++ b/SHMEM/isx.c
@@ -894,7 +894,7 @@ static void create_permutation_array()
 }
 
 /*
- * Randomly shuffles a generic array
+ * Randomly shuffles an array of PE ids
  */
 static void shuffle(int* array, size_t n) {
     struct timeval tv;

--- a/SHMEM/isx.c
+++ b/SHMEM/isx.c
@@ -890,26 +890,27 @@ static void create_permutation_array()
     permute_array[i] = i;
   }
 
-  shuffle(permute_array, NUM_PES, sizeof(int));
+  shuffle(permute_array, NUM_PES);
 }
 
 /*
  * Randomly shuffles a generic array
  */
-static void shuffle(void * array, size_t n, size_t size)
-{
-  char tmp[size];
-  char * arr = array;
-  size_t stride = size * sizeof(char);
-  if(n > 1){
-    for(size_t i = 0; i < (n - 1); ++i){
-      size_t rnd = (size_t) rand();
-      size_t j = i + rnd/(RAND_MAX/(n - i) + 1);
-      memcpy(tmp, arr + j*stride, size);
-      memcpy(arr + j*stride, arr + i*stride, size);
-      memcpy(arr + i*stride, tmp, size);
+static void shuffle(int* array, size_t n) {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    int usec = tv.tv_usec;
+    srand48(usec);
+
+    if (n > 1) {
+        size_t i;
+        for (i = n - 1; i > 0; i--) {
+            size_t j = (unsigned int) (drand48()*(i+1));
+            int t = array[j];
+            array[j] = array[i];
+            array[i] = t;
+        }
     }
-  }
 }
 #endif
 

--- a/SHMEM/isx.h
+++ b/SHMEM/isx.h
@@ -58,7 +58,7 @@ static void create_permutation_array();
 /*
  * Randomly shuffles a generic array
  */
-static void shuffle(void * array, size_t n, size_t size);
+static void shuffle(int* array, size_t n);
 #endif
 
 


### PR DESCRIPTION
Fixed the bug in the shuffle function that is currently generating the same random set of PEs across all PEs. Also, implemented the shuffle function for specific integer types rather than keeping it generic, which is not required.

Signed-off-by: Md <md.rahman@intel.com>