### PR TITLE
Correcting conversion of ascii to uint64_t

### DIFF
--- a/MPI/Makefile
+++ b/MPI/Makefile
@@ -1,4 +1,4 @@
-CC = cc
+CC = mpicc
 LD = $(CC)
 DEBUGFLAGS = -g -p -O0 -DDEBUG
 OPTFLAGS = -O3 -DNDEBUG -mavx

--- a/MPI/isx.c
+++ b/MPI/isx.c
@@ -103,7 +103,7 @@ static char * parse_params(const int argc, char ** argv)
   switch(SCALING_OPTION){
     case STRONG:
       {
-        TOTAL_KEYS = (uint64_t) atoi(argv[1]);
+        TOTAL_KEYS = (uint64_t) strtoull(argv[1], NULL, 10);
         NUM_KEYS_PER_PE = (uint64_t) ceil((double)TOTAL_KEYS/NUM_PES);
         sprintf(scaling_msg,"STRONG");
         break;
@@ -111,14 +111,14 @@ static char * parse_params(const int argc, char ** argv)
 
     case WEAK:
       {
-        NUM_KEYS_PER_PE = (uint64_t) (atoi(argv[1]));
+        NUM_KEYS_PER_PE = (uint64_t) (strtoull(argv[1], NULL, 10));
         sprintf(scaling_msg,"WEAK");
         break;
       }
 
     case WEAK_ISOBUCKET:
       {
-        NUM_KEYS_PER_PE = (uint64_t) (atoi(argv[1]));
+        NUM_KEYS_PER_PE = (uint64_t) (strtoull(argv[1], NULL, 10)); 
         BUCKET_WIDTH = ISO_BUCKET_WIDTH; 
         MAX_KEY_VAL = (uint64_t) (NUM_PES * BUCKET_WIDTH);
         sprintf(scaling_msg,"WEAK_ISOBUCKET");

--- a/SHMEM/Makefile
+++ b/SHMEM/Makefile
@@ -1,4 +1,4 @@
-CC = cc
+CC = oshcc
 LD = $(CC)
 DEBUGFLAGS = -g -p -O0 -DDEBUG
 OPTFLAGS = -O3 -DNDEBUG -mavx

--- a/SHMEM/isx.c
+++ b/SHMEM/isx.c
@@ -122,8 +122,7 @@ static char * parse_params(const int argc, char ** argv)
   switch(SCALING_OPTION){
     case STRONG:
       {
-        //TOTAL_KEYS = (uint64_t) atoi(argv[1]);
-        TOTAL_KEYS = (uint64_t) strtoull(argv[1], NULL, 10);            // correcting conversion from ascii to uint64_t
+        TOTAL_KEYS = (uint64_t) strtoull(argv[1], NULL, 10);        
         NUM_KEYS_PER_PE = (uint64_t) ceil((double)TOTAL_KEYS/NUM_PES);
         sprintf(scaling_msg,"STRONG");
         break;
@@ -131,16 +130,14 @@ static char * parse_params(const int argc, char ** argv)
 
     case WEAK:
       {
-        //NUM_KEYS_PER_PE = (uint64_t) (atoi(argv[1]));
-        NUM_KEYS_PER_PE = (uint64_t) (strtoull(argv[1], NULL, 10));         // correcting conversion from ascii to uint64_t
+        NUM_KEYS_PER_PE = (uint64_t) (strtoull(argv[1], NULL, 10));     
         sprintf(scaling_msg,"WEAK");
         break;
       }
 
     case WEAK_ISOBUCKET:
       {
-        //NUM_KEYS_PER_PE = (uint64_t) (atoi(argv[1]));
-        NUM_KEYS_PER_PE = (uint64_t) (strtoull(argv[1], NULL, 10));         // correcting conversion from ascii to uint64_t
+        NUM_KEYS_PER_PE = (uint64_t) (strtoull(argv[1], NULL, 10));     
         BUCKET_WIDTH = ISO_BUCKET_WIDTH; 
         MAX_KEY_VAL = (uint64_t) (NUM_PES * BUCKET_WIDTH);
         sprintf(scaling_msg,"WEAK_ISOBUCKET");

--- a/SHMEM/isx.c
+++ b/SHMEM/isx.c
@@ -122,7 +122,8 @@ static char * parse_params(const int argc, char ** argv)
   switch(SCALING_OPTION){
     case STRONG:
       {
-        TOTAL_KEYS = (uint64_t) atoi(argv[1]);
+        //TOTAL_KEYS = (uint64_t) atoi(argv[1]);
+        TOTAL_KEYS = (uint64_t) strtoull(argv[1], NULL, 10);            // correcting conversion from ascii to uint64_t
         NUM_KEYS_PER_PE = (uint64_t) ceil((double)TOTAL_KEYS/NUM_PES);
         sprintf(scaling_msg,"STRONG");
         break;
@@ -130,14 +131,16 @@ static char * parse_params(const int argc, char ** argv)
 
     case WEAK:
       {
-        NUM_KEYS_PER_PE = (uint64_t) (atoi(argv[1]));
+        //NUM_KEYS_PER_PE = (uint64_t) (atoi(argv[1]));
+        NUM_KEYS_PER_PE = (uint64_t) (strtoull(argv[1], NULL, 10));         // correcting conversion from ascii to uint64_t
         sprintf(scaling_msg,"WEAK");
         break;
       }
 
     case WEAK_ISOBUCKET:
       {
-        NUM_KEYS_PER_PE = (uint64_t) (atoi(argv[1]));
+        //NUM_KEYS_PER_PE = (uint64_t) (atoi(argv[1]));
+        NUM_KEYS_PER_PE = (uint64_t) (strtoull(argv[1], NULL, 10));         // correcting conversion from ascii to uint64_t
         BUCKET_WIDTH = ISO_BUCKET_WIDTH; 
         MAX_KEY_VAL = (uint64_t) (NUM_PES * BUCKET_WIDTH);
         sprintf(scaling_msg,"WEAK_ISOBUCKET");


### PR DESCRIPTION
atoi function used will not do correct type conversion for more than 2^31 problem size provided as a command line argument. Replaced the "atoi" by "strtoull".